### PR TITLE
Adds build script to compile for prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "react-dev": "webpack -d --watch",
+    "build": "webpack --mode production",
     "start": "nodemon server/index.js"
   },
   "repository": {


### PR DESCRIPTION
When I was getting this set up, I ended up adding this build script to get it to boot, but I think I was probably just running the `react-dev` one wrong, so while this may not be needed right now, I think we'll need it later once we deploy it somewhere.